### PR TITLE
修正手動引入的 Ant Design Vue 元件覆蓋 WindiCSS 樣式問題

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -5,6 +5,10 @@ import '@vue/runtime-core'
 
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
+    ACard: typeof import('ant-design-vue/es')['Card']
+    ACol: typeof import('ant-design-vue/es')['Col']
+    ARow: typeof import('ant-design-vue/es')['Row']
+    ASpace: typeof import('ant-design-vue/es')['Space']
     Default: typeof import('./src/layouts/default.vue')['default']
     DemoFormLogin: typeof import('./src/components/DemoFormLogin.vue')['default']
     DemoFormPersonal: typeof import('./src/components/DemoFormPersonal.vue')['default']

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { useUserStore } from './stores/user'
+// 引入 ant design 全域樣式
+import 'ant-design-vue/dist/antd.less'
+
 // 保持登入功能
 const user = localStorage.getItem('user')
 const userStore = useUserStore()

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 
 import 'virtual:windi.css'
-import 'ant-design-vue/dist/antd.less'
 // 全域註冊部分元件，其餘元件仍須手動引入(勿更動)
 import { Space, Row, Col, Card } from 'ant-design-vue'
 const GloballyRegisteredAntdComponents = [Space, Row, Col, Card]

--- a/src/pages/management/teams.vue
+++ b/src/pages/management/teams.vue
@@ -127,17 +127,17 @@ const handleDeleteTeam = () => {
 	<a-row :gutter="24">
 		<!-- 樹狀列表 -->
 		<a-col :xs="24" :md="6">
-			<div v-if="allTeamsData.length">
-				<Tree
-					v-model:selectedKeys="treeSelectedKeys"
-					v-model:expandedKeys="treeExpandedKeys"
-					:tree-data="treeData"
-				>
-					<template #title="{ dataRef }">
-						{{ dataRef.title }}
-					</template>
-				</Tree>
-			</div>
+			<Tree
+				v-if="allTeamsData.length"
+				v-model:selectedKeys="treeSelectedKeys"
+				v-model:expandedKeys="treeExpandedKeys"
+				:tree-data="treeData"
+				class="px-2 py-4"
+			>
+				<template #title="{ dataRef }">
+					{{ dataRef.title }}
+				</template>
+			</Tree>
 			<Spin v-else />
 		</a-col>
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,8 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 import Components from 'unplugin-vue-components/vite'
-
 import Pages from 'vite-plugin-pages'
 import Layouts from 'vite-plugin-vue-layouts'
-
 import WindiCSS from 'vite-plugin-windicss'
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
把 Ant Design Vue 的全域 less 檔改放在 App.vue 中